### PR TITLE
Support template strings for test names

### DIFF
--- a/src/parser/codeParser.ts
+++ b/src/parser/codeParser.ts
@@ -21,13 +21,25 @@ function codeParser(sourceCode) {
       if (!nextToken.type.startsExpr) {
         return;
       }
-
+    
+     
       return {
         loc,
-        testName: ast.tokens[index + 2].value,
+        testName: getTestNameFromToken(ast.tokens[index + 2]),
       };
     })
     .filter(Boolean);
+}
+
+function getTestNameFromToken(token) {
+  switch(token.type) {
+    case 'Literal':
+      return token.value;
+    case 'TemplateElement':
+      return token.value.raw;
+    default:
+      throw Error(`Unexepected token type for testName: ${token.type}`);
+  }
 }
 
 export { codeParser };

--- a/src/parser/codeParser.ts
+++ b/src/parser/codeParser.ts
@@ -21,8 +21,7 @@ function codeParser(sourceCode) {
       if (!nextToken.type.startsExpr) {
         return;
       }
-    
-     
+
       return {
         loc,
         testName: getTestNameFromToken(ast.tokens[index + 2]),


### PR DESCRIPTION
We enforce all strings to be template strings in our codebase which breaks this extension. This change adds support for template strings.